### PR TITLE
Docs/46 add academy section to org overview

### DIFF
--- a/assets/layer5-academy-icon.svg
+++ b/assets/layer5-academy-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <style>
+      .building-icon { fill: #00b39f; }
+      svg { background-color: transparent; }
+    </style>
+  </defs>
+  <path d="M496 128v16a8 8 0 0 1-8 8h-24v12c0 6.627-5.373 12-12 12H60c-6.627 0-12-5.373-12-12v-12H24a8 8 0 0 1-8-8v-16a8 8 0 0 1 4.941-7.392l232-88a7.996 7.996 0 0 1 6.118 0l232 88A8 8 0 0 1 496 128zm-24 304H40c-13.255 0-24 10.745-24 24v16a8 8 0 0 0 8 8h464a8 8 0 0 0 8-8v-16c0-13.255-10.745-24-24-24zM96 192v192H60c-6.627 0-12 5.373-12 12v20h416v-20c0-6.627-5.373-12-12-12h-36V192h-64v192h-64V192h-64v192h-64V192H96z" 
+        class="building-icon"/>
+</svg>

--- a/profile/README.md
+++ b/profile/README.md
@@ -129,10 +129,8 @@ Use <a href="https://layer5.io/cloud-native-management/kanvas">Kanvas</a> to dra
 <br />
 
 <!-- Layer5 Academy -->
-<div style="clear:both;">
-  <h2>
-    <a href="https://docs.layer5.io/cloud/academy/">Layer5 Academy</a>
-  </h2>
+<p style="clear:both;">
+  <h2><a href="https://docs.layer5.io/cloud/academy/">Layer5 Academy</a></h2>
 
   <a href="https://cloud.layer5.io/academy">
     <img src="/assets/layer5-academy-icon.svg"
@@ -141,18 +139,20 @@ Use <a href="https://layer5.io/cloud-native-management/kanvas">Kanvas</a> to dra
          alt="Layer5 Academy - Learning Platform"
          align="left" />
   </a>
- <p>
-  <a href="https://cloud.layer5.io/academy/">Layer5 Academy</a> offers a comprehensive learning platform for cloud native enthusiasts, providing free, interactive courses and hands-on labs. Dive into Kubernetes, CNCF projects, and cloud native infrastructure management with structured learning paths tailored for beginners and advanced practitioners alike.
+
+  <a href="https://cloud.layer5.io/academy/">Layer5 Academy</a> offers a comprehensive learning platform for cloud native enthusiasts, providing free, interactive courses and hands-on labs. Dive into Kubernetes, CNCF projects, and cloud native infrastructure management with structured learning paths tailored for beginners and advanced practitioners alike.  
   You can explore all the 
   <a href="https://github.com/search?q=org%3Alayer5io+academy+in%3Aname&type=repositories">repositories here</a>.
-
-<a href="https://github.com/search?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+org%3Alayer5io+academy" alt="Help Wanted in Academy">
-  <img 
-    alt="Help Wanted in Academy" 
-    src="https://img.shields.io/github/issues-search?label=Help%20Wanted&query=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22+org%3Alayer5io+academy">
-</a>
-<br/>
+  <br />
+  <br />
+  <a href="https://github.com/search?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+org%3Alayer5io+academy" alt="Help Wanted in Academy">
+    <img 
+      alt="Help Wanted in Academy" 
+      src="https://img.shields.io/github/issues-search?label=Help%20Wanted&query=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22+org%3Alayer5io+academy">
+  </a>
+  <br />
 </p>
+
 
 <!-- Cloud Native Patterns -->
 <p style="clear:both;">

--- a/profile/README.md
+++ b/profile/README.md
@@ -145,13 +145,14 @@ Use <a href="https://layer5.io/cloud-native-management/kanvas">Kanvas</a> to dra
   <a href="https://cloud.layer5.io/academy/">Layer5 Academy</a> offers a comprehensive learning platform for cloud native enthusiasts, providing free, interactive courses and hands-on labs. Dive into Kubernetes, CNCF projects, and cloud native infrastructure management with structured learning paths tailored for beginners and advanced practitioners alike.
   You can explore all the 
   <a href="https://github.com/search?q=org%3Alayer5io+academy+in%3Aname&type=repositories">repositories here</a>.
-</p>
+
 <a href="https://github.com/search?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+org%3Alayer5io+academy" alt="Help Wanted in Academy">
   <img 
     alt="Help Wanted in Academy" 
     src="https://img.shields.io/github/issues-search?label=Help%20Wanted&query=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22+org%3Alayer5io+academy">
 </a>
 <br/>
+</p>
 
 <!-- Cloud Native Patterns -->
 <p style="clear:both;">

--- a/profile/README.md
+++ b/profile/README.md
@@ -308,4 +308,3 @@ src="https://github.com/layer5io/.github/blob/master/assets/social-icons/youtube
 <a href="https://hub.docker.com/u/layer5/"><img alt="docker_logo" 
 src="https://github.com/layer5io/.github/blob/master/assets/social-icons/docker.svg"></a>
 </p>
-s

--- a/profile/README.md
+++ b/profile/README.md
@@ -151,7 +151,7 @@ Use <a href="https://layer5.io/cloud-native-management/kanvas">Kanvas</a> to dra
     alt="Help Wanted in Academy" 
     src="https://img.shields.io/github/issues-search?label=Help%20Wanted&query=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22+org%3Alayer5io+academy">
 </a>
-</br>
+<br/>
 
 <!-- Cloud Native Patterns -->
 <p style="clear:both;">

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,4 @@
+
   <p style="text-align:center;" align="center">
       <picture align="center">
          <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/layer5io/layer5/master/.github/assets/images/layer5/layer5-light-no-trim.svg">
@@ -114,6 +115,8 @@ alt="Meshery - Collaborative Cloud Native Manager" align="left" /></a>
 </p>
 <br />
 
+
+
 <!-- Kanvas -->
 <p style="clear:both;">
 <h2><a href="https://layer5.io/cloud-native-management/kanvas">Kanvas</a></h2>
@@ -124,6 +127,31 @@ Use <a href="https://layer5.io/cloud-native-management/kanvas">Kanvas</a> to dra
 <br /><br /><br />
 </p>
 <br />
+
+<!-- Layer5 Academy -->
+<div style="clear:both;">
+  <h2>
+    <a href="https://docs.layer5.io/cloud/academy/">Layer5 Academy</a>
+  </h2>
+
+  <a href="https://cloud.layer5.io/academy">
+    <img src="/assets/layer5-academy-icon.svg"
+         style="margin:10px;"
+         width="125px"
+         alt="Layer5 Academy - Learning Platform"
+         align="left" />
+  </a>
+ <p>
+  <a href="https://cloud.layer5.io/academy/">Layer5 Academy</a> offers a comprehensive learning platform for cloud native enthusiasts, providing free, interactive courses and hands-on labs. Dive into Kubernetes, CNCF projects, and cloud native infrastructure management with structured learning paths tailored for beginners and advanced practitioners alike.
+  You can explore all the 
+  <a href="https://github.com/search?q=org%3Alayer5io+academy+in%3Aname&type=repositories">repositories here</a>.
+</p>
+<a href="https://github.com/search?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+org%3Alayer5io+academy" alt="Help Wanted in Academy">
+  <img 
+    alt="Help Wanted in Academy" 
+    src="https://img.shields.io/github/issues-search?label=Help%20Wanted&query=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22+org%3Alayer5io+academy">
+</a>
+</br>
 
 <!-- Cloud Native Patterns -->
 <p style="clear:both;">
@@ -279,3 +307,4 @@ src="https://github.com/layer5io/.github/blob/master/assets/social-icons/youtube
 <a href="https://hub.docker.com/u/layer5/"><img alt="docker_logo" 
 src="https://github.com/layer5io/.github/blob/master/assets/social-icons/docker.svg"></a>
 </p>
+s


### PR DESCRIPTION
**Description**

This PR fixes #46

Add a new section with icon, description, and link or links to repo(s).
Uses the same Academy icon from [Layer5 Academy](https://cloud.layer5.io/academy).
Colorized using brand colors like `#00b39f`.

**Notes for Reviewers**

- Please review the icon placement and color usage.
- Confirm if the brand color and layout are aligned with design guidelines.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<img width="1352" height="552" alt="Screenshot 2025-07-23 191731" src="https://github.com/user-attachments/assets/d48c3c6a-6ae7-4080-afa9-542dd82509fb" />
